### PR TITLE
Remove Mock Import Path Hack

### DIFF
--- a/test/ping.test.mjs
+++ b/test/ping.test.mjs
@@ -1,6 +1,5 @@
 import { createRequire } from "module";
 import esmock from "esmock";
-import path from "path";
 import sinon from "sinon";
 
 const require = createRequire(import.meta.url);
@@ -12,7 +11,7 @@ describe("localhost ping", () => {
 
   const mockImport = () =>
     esmock("../dist/ping.mjs", {
-      [require.resolve("ping").replaceAll(path.sep, "/")]: stubs.ping,
+      [require.resolve("ping")]: stubs.ping,
     });
 
   it("should ping the localhost", async () => {


### PR DESCRIPTION
This pull request eliminates the need for the mock import path hack, which has been resolved after upgrading ESMock to the latest version (#59). 

**EDIT**: well apparently it is not 💀.