### PR TITLE
Simplify Mock Import

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
     branches: [main]
+env:
+  NODE_OPTIONS: --experimental-import-meta-resolve
 jobs:
   package:
     runs-on: ${{ matrix.os }}-latest

--- a/test/ping.test.mjs
+++ b/test/ping.test.mjs
@@ -1,28 +1,21 @@
-import { createRequire } from "module";
 import esmock from "esmock";
-import path from "path";
 import sinon from "sinon";
-
-const require = createRequire(import.meta.url);
 
 describe("localhost ping", () => {
   const stubs = {
     ping: { promise: { probe: sinon.stub() } },
   };
 
-  const mockImport = () =>
-    esmock("../dist/ping.mjs", {
-      [require.resolve("ping").replaceAll(path.sep, "/")]: stubs.ping,
-    });
+  const mockImport = () => esmock("../dist/ping.mjs", { ping: stubs.ping });
 
   it("should ping the localhost", async () => {
-    const { pingLocalhost } = await mockImport("../dist/ping.mjs");
+    const { pingLocalhost } = await mockImport();
     stubs.ping.promise.probe.resolves({ alive: true });
     pingLocalhost().should.eventually.be.true;
   });
 
   it("should not ping the localhost", async () => {
-    const { pingLocalhost } = await mockImport("../dist/ping.mjs");
+    const { pingLocalhost } = await mockImport();
     stubs.ping.promise.probe.resolves({ alive: false });
     pingLocalhost().should.eventually.be.false;
   });


### PR DESCRIPTION
This pull request simplifies mock imports by enabling the [`import.meta.resolve()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve) function within Node.js through the use of `NODE_OPTIONS`. This enhancement eliminates the need for [esmock](https://github.com/iambumblehead/esmock) to utilize [resolvewithplus](https://www.npmjs.com/package/resolvewithplus), which was causing issues due to its buggy behavior. The previous workaround that involved using `createRequire(import.meta.url)` to enable dependency resolution is no longer necessary with this approach.