### PR TITLE
Revert Module Path Resolution for Mocking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches: [main]
-env:
-  NODE_OPTIONS: --experimental-import-meta-resolve
 jobs:
   test:
     name: Test

--- a/test/ping.test.mjs
+++ b/test/ping.test.mjs
@@ -1,12 +1,19 @@
+import { createRequire } from "module";
 import esmock from "esmock";
+import path from "path";
 import sinon from "sinon";
+
+const require = createRequire(import.meta.url);
 
 describe("localhost ping", () => {
   const stubs = {
     ping: { promise: { probe: sinon.stub() } },
   };
 
-  const mockImport = () => esmock("../dist/ping.mjs", { ping: stubs.ping });
+  const mockImport = () =>
+    esmock("../dist/ping.mjs", {
+      [require.resolve("ping").replaceAll(path.sep, "/")]: stubs.ping,
+    });
 
   it("should ping the localhost", async () => {
     const { pingLocalhost } = await mockImport();

--- a/test/ping.test.mjs
+++ b/test/ping.test.mjs
@@ -12,7 +12,8 @@ describe("localhost ping", () => {
 
   const mockImport = () =>
     esmock("../dist/ping.mjs", {
-      [require.resolve("ping").replaceAll(path.sep, "/")]: stubs.ping,
+      [`file://${require.resolve("ping").replaceAll(path.sep, "/")}`]:
+        stubs.ping,
     });
 
   it("should ping the localhost", async () => {


### PR DESCRIPTION
This pull request reverts the method of module path resolution used for mocking by leveraging the `createRequire(import.meta.url)` function.