### PR TITLE
Configure Dependabot Versioning Strategy

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,3 +15,4 @@ updates:
     commit-message:
       prefix: chore
     labels: [chore]
+    versioning-strategy: increase


### PR DESCRIPTION
This pull request configures the Dependabot versioning strategy to always increment the version when there's a new update.