### PR TITLE
Rename to Node.js Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Node.ts Starter
+# Node.js Starter
 
 [![CI status](https://img.shields.io/github/actions/workflow/status/threeal/node-ts-starter/ci.yaml?branch=main&label=CI&style=flat-square)](https://github.com/threeal/node-ts-starter/actions/workflows/test.yaml)
 
-Kickstart your [Node](https://nodejs.org/en)-[TypeScript](https://www.typescriptlang.org/) project with this [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template). This repository provides a minimalistic template for Node.js, featuring support for TypeScript compilation, [Prettier](https://prettier.io/) for code formatting, [ESLint](https://eslint.org/) for static linting, and [Jest](https://jestjs.io/) for testing.
+Kickstart your [Node.js](https://nodejs.org/en) project using this [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template). This repository provides a minimalistic template for Node.js, featuring support for [TypeScript](https://www.typescriptlang.org/) compilation, [Prettier](https://prettier.io/) for code formatting, [ESLint](https://eslint.org/) for static linting, and [Jest](https://jestjs.io/) for testing.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Node.js Starter
 
-[![CI status](https://img.shields.io/github/actions/workflow/status/threeal/node-ts-starter/ci.yaml?branch=main&label=CI&style=flat-square)](https://github.com/threeal/node-ts-starter/actions/workflows/test.yaml)
+[![CI status](https://img.shields.io/github/actions/workflow/status/threeal/nodejs-starter/ci.yaml?branch=main&label=CI&style=flat-square)](https://github.com/threeal/nodejs-starter/actions/workflows/ci.yaml)
 
 Kickstart your [Node.js](https://nodejs.org/en) project using this [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template). This repository provides a minimalistic template for Node.js, featuring support for [TypeScript](https://www.typescriptlang.org/) compilation, [Prettier](https://prettier.io/) for code formatting, [ESLint](https://eslint.org/) for static linting, and [Jest](https://jestjs.io/) for testing.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "keyword",
     "other-keyword"
   ],
-  "homepage": "https://github.com/threeal/node-ts-starter#readme",
+  "homepage": "https://github.com/threeal/nodejs-starter#readme",
   "bugs": {
-    "url": "https://github.com/threeal/node-ts-starter/issues",
+    "url": "https://github.com/threeal/nodejs-starter/issues",
     "email": "threeal@github.com"
   },
-  "repository": "github:threeal/node-ts-starter",
+  "repository": "github:threeal/nodejs-starter",
   "license": "Unlicense",
   "author": "threeal <threeal@github.com>",
   "type": "module",


### PR DESCRIPTION
This pull request straightforwardly renames the project to "Node.js Starter" and updates the GitHub URL to `github.com/threeal/nodejs-starter`. It effectively closes #37.