### PR TITLE
Limit GitHub Pages Deployment to the `main` Branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
 
   deploy:
     name: Deploy
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
     needs: test
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This pull request makes a straightforward adjustment by restricting the "Deploy" job within the CI workflow to execute only when the branch name is `main`. It closes #139.