### PR TITLE
Upload Documentations Artifact Only on Ubuntu Workflow Run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
         run: yarn doc
 
       - name: Upload docs artifact
+        if: ${{ matrix.os }} == "ubuntu"
         uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: docs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [Windows, Ubuntu, macOS]
+        os: [windows, ubuntu, macos]
     env:
       NODE_OPTIONS: --experimental-vm-modules
     steps:


### PR DESCRIPTION
This pull request adjusts the CI workflow to ensure that the "Upload docs artifact" step is exclusively run during an Ubuntu workflow. Additionally, it renames the OS names in the matrix to use lowercase formatting.