### PR TITLE
Disable Jest Globals Injections

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,12 +17,6 @@
       "rules": {
         "tsdoc/syntax": "error"
       }
-    },
-    {
-      "files": ["**/*.test.*"],
-      "env": {
-        "jest": true
-      }
     }
   ]
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -9,6 +9,7 @@
     }
   },
   "extensionsToTreatAsEsm": [".ts", ".mts"],
+  "injectGlobals": false,
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.mjs$": "$1.mts"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
-    "@types/jest": "^29.5.8",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "eslint": "^8.53.0",

--- a/src/sequence.test.ts
+++ b/src/sequence.test.ts
@@ -1,3 +1,4 @@
+import { it, expect } from "@jest/globals";
 import { fibonacciSequence } from "./sequence.mjs";
 
 it("should generate a fibonacci sequence", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,16 +1063,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^29.5.8":
-  version: 29.5.8
-  resolution: "@types/jest@npm:29.5.8"
-  dependencies:
-    expect: "npm:^29.0.0"
-    pretty-format: "npm:^29.0.0"
-  checksum: a28e7827ea7e1a2aace6a386868fa6b8402c162d6c71570aed2c29d3745ddc22ceef6899a20643071817905d3c57b670a7992fc8760bff65939351fd4dc481cf
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:^7.0.12":
   version: 7.0.12
   resolution: "@types/json-schema@npm:7.0.12"
@@ -2323,7 +2313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.0.0, expect@npm:^29.7.0":
+"expect@npm:^29.7.0":
   version: 29.7.0
   resolution: "expect@npm:29.7.0"
   dependencies:
@@ -4405,7 +4395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
+"pretty-format@npm:^29.7.0":
   version: 29.7.0
   resolution: "pretty-format@npm:29.7.0"
   dependencies:
@@ -4834,7 +4824,6 @@ __metadata:
   resolution: "starter@workspace:."
   dependencies:
     "@jest/globals": "npm:^29.7.0"
-    "@types/jest": "npm:^29.5.8"
     "@typescript-eslint/eslint-plugin": "npm:^6.10.0"
     "@typescript-eslint/parser": "npm:^6.10.0"
     eslint: "npm:^8.53.0"


### PR DESCRIPTION
This pull request disables Jest global injections, requiring testing files to manually import Jest functions from `@jest/globals`. Additionally, it removes the Jest environment from the ESLint configuration and eliminates the `@types/jest` package from the dependencies. It closes #165.