### PR TITLE
Remove Clean Command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,6 @@ jobs:
       - name: Install deps
         run: yarn install
 
-      - name: Clean dist
-        run: yarn clean
-
       - name: Build dist
         run: yarn nx build
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf dist",
     "doc": "typedoc src/index.mts",
     "format": "prettier --write . !dist",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "jest": "^29.7.0",
     "nx": "17.0.3",
     "prettier": "^3.0.3",
-    "rimraf": "^5.0.5",
     "sort-package-json": "^2.6.0",
     "ts-jest": "^29.1.1",
     "typedoc": "^0.25.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,21 +2681,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.7":
-  version: 10.3.10
-  resolution: "glob@npm:10.3.10"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^2.3.5"
-    minimatch: "npm:^9.0.1"
-    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
-    path-scurry: "npm:^1.10.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 13d8a1feb7eac7945f8c8480e11cd4a44b24d26503d99a8d8ac8d5aefbf3e9802a2b6087318a829fad04cb4e829f25c5f4f1110c68966c498720dd261c7e344d
-  languageName: node
-  linkType: hard
-
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -3121,19 +3106,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 70b286206a2729f6a2ba8470f68d4d130f7154f6a767fccabf107b9f6b3871395e89018437c2676c849450b258711cb557a4be6d7b2f889f1fa4d8b364533225
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^2.3.5":
-  version: 2.3.6
-  resolution: "jackspeak@npm:2.3.6"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: f01d8f972d894cd7638bc338e9ef5ddb86f7b208ce177a36d718eac96ec86638a6efa17d0221b10073e64b45edc2ce15340db9380b1f5d5c5d000cbc517dc111
   languageName: node
   linkType: hard
 
@@ -4041,7 +4013,6 @@ __metadata:
     jest: "npm:^29.7.0"
     nx: "npm:17.0.3"
     prettier: "npm:^3.0.3"
-    rimraf: "npm:^5.0.5"
     sort-package-json: "npm:^2.6.0"
     ts-jest: "npm:^29.1.1"
     typedoc: "npm:^0.25.3"
@@ -4631,17 +4602,6 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
-  languageName: node
-  linkType: hard
-
-"rimraf@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "rimraf@npm:5.0.5"
-  dependencies:
-    glob: "npm:^10.3.7"
-  bin:
-    rimraf: dist/esm/bin.mjs
-  checksum: d50dbe724f33835decd88395b25ed35995077c60a50ae78ded06e0185418914e555817aad1b4243edbff2254548c2f6ad6f70cc850040bebb4da9e8cc016f586
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces the following changes:
- Remove the `clean` command.
- Remove step for cleaning the distribution files in the workflow.
- Remove [rimraf](https://www.npmjs.com/package/rimraf) from the dependency.