### PR TITLE
Simplify Commands Calls

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,11 +56,11 @@ jobs:
       - name: Install Dependencies
         run: corepack enable && yarn install
 
-      - name: Check Changes
-        run: git diff --exit-code HEAD
+      - name: Check Package
+        run: yarn check && git diff --exit-code HEAD
 
       - name: Test Package
-        run: yarn nx test
+        run: yarn test
 
   generate-docs:
     name: Generate Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage/
 dist/
 docs/
 node_modules/
+
+package.tgz

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "doc", "format", "lint", "sort"]
+        "cacheableOperations": ["doc", "format", "lint", "sort"]
       }
     }
   },
@@ -11,14 +11,6 @@
     "dependencies": ["{projectRoot}/.pnp.*", "{projectRoot}/package.json"]
   },
   "targetDefaults": {
-    "build": {
-      "dependsOn": ["lint"],
-      "inputs": [
-        "dependencies",
-        "{projectRoot}/src/**/*",
-        "{projectRoot}/tsconfig.json"
-      ]
-    },
     "doc": {
       "dependsOn": ["lint"],
       "inputs": ["dependencies", "{projectRoot}/src/**/*"]

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["doc", "format", "lint", "sort"]
+        "cacheableOperations": ["check", "doc"]
       }
     }
   },
@@ -11,28 +11,15 @@
     "dependencies": ["{projectRoot}/.pnp.*", "{projectRoot}/package.json"]
   },
   "targetDefaults": {
-    "doc": {
-      "dependsOn": ["lint"],
-      "inputs": ["dependencies", "{projectRoot}/src/**/*"]
-    },
-    "format": {
-      "dependsOn": ["sort"],
+    "check": {
       "inputs": ["dependencies", "{projectRoot}/**/*", "{projectRoot}/**/.*"]
     },
-    "lint": {
-      "dependsOn": ["format"],
-      "inputs": [
-        "dependencies",
-        "{projectRoot}/src/**/*",
-        "{projectRoot}/test/**/*",
-        "{projectRoot}/.eslintrc.json"
-      ]
-    },
-    "sort": {
-      "inputs": ["dependencies"]
+    "doc": {
+      "dependsOn": ["check"],
+      "inputs": ["dependencies", "{projectRoot}/src/**/*"]
     },
     "test": {
-      "dependsOn": ["lint"]
+      "dependsOn": ["check"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,9 @@
     "dist"
   ],
   "scripts": {
+    "check": "sort-package-json && prettier --write . !dist && eslint src",
     "doc": "typedoc src/index.mts",
-    "format": "prettier --write . !dist",
-    "lint": "eslint src",
     "prepack": "tsc",
-    "sort": "sort-package-json",
     "test": "jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
     "doc": "typedoc src/index.mts",
     "format": "prettier --write . !dist",
     "lint": "eslint src",
-    "prepack": "nx build",
+    "prepack": "tsc",
     "sort": "sort-package-json",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request simplifies commands calls as follows:
- Use `prepack` in replacement of `build` command (`prepack` will be called before calling `pack`).
- Use `check` in replacement of `format`, `lint`, and `sort` commands.

This pull request also introduces the following changes:
- Ignore `package.tgz` using the `.gitignore` file.
- Modify Check Changes step with Check Packages step in the Build workflow.
- Adjust commands dependencies in the Nx configuration accordingly.

It closes #178.