### PR TITLE
Add Git Attributes for Yarn Lock File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+yarn.lock -diff linguist-generated=true


### PR DESCRIPTION
This pull request adds a `.gitattributes` file that sets attributes for the `yarn.lock` file. It closes #194.