### PR TITLE
Adjust Prettier Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "check": "sort-package-json && prettier --write . !dist && eslint src",
+    "check": "sort-package-json && prettier --write . && eslint src",
     "doc": "typedoc src/index.mts",
     "prepack": "tsc",
     "test": "jest"


### PR DESCRIPTION
This pull request removes the explicit specification to ignore the `dist` directory for Prettier since it is already covered by the patterns in the `.gitignore` file.