### PR TITLE
Use `.gitignore` in ESLint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "check": "prettier --write . && eslint src package.json",
+    "check": "prettier --write . && eslint --ignore-path .gitignore .",
     "doc": "typedoc src/index.mts",
     "prepack": "tsc",
     "test": "jest"


### PR DESCRIPTION
This pull requests modify ESLint to use `.gitignore` for ignoring files. It closes #203.