### PR TITLE
Modify Check Command to Fix Command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Install Dependencies
         run: corepack enable && yarn install
 
-      - name: Check Package
-        run: yarn check && git diff --exit-code HEAD
+      - name: Fix Package
+        run: yarn fix && git diff --exit-code HEAD
 
       - name: Create Package
         run: yarn pack

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "check": "prettier --write . && eslint --fix --ignore-path .gitignore .",
     "doc": "typedoc src/index.mts",
+    "fix": "prettier --write . && eslint --fix --ignore-path .gitignore .",
     "prepack": "tsc",
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "check": "prettier --write . && eslint --ignore-path .gitignore .",
+    "check": "prettier --write . && eslint --fix --ignore-path .gitignore .",
     "doc": "typedoc src/index.mts",
     "prepack": "tsc",
     "test": "jest"


### PR DESCRIPTION
This pull request introduces the following changes:
- Modify `check` command to be `fix` command.
- Run ESLint with `--fix` option in the `fix` command.
- Rename `Check Package` step to `Fix Package` step in the `Build` workflow.

It closes #205.