### PR TITLE
Separate `fix` Command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,11 @@ jobs:
       - name: Install Dependencies
         run: corepack enable && yarn install
 
-      - name: Fix Package
-        run: yarn fix && git diff --exit-code HEAD
+      - name: Check Format
+        run: yarn format && git diff --exit-code HEAD
+
+      - name: Check Lint
+        run: yarn lint
 
       - name: Create Package
         run: yarn pack

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "scripts": {
     "doc": "typedoc src/index.mts",
-    "fix": "prettier --write . && eslint --fix --ignore-path .gitignore .",
+    "format": "prettier --write .",
+    "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request separates the `fix` command to `format` and `lint` commands. The `lint` commands will just check for linting errors and won't try to fix the code. It closes #208.