### PR TITLE
Run Only on Latest Ubuntu in Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,11 +32,7 @@ jobs:
 
   test-package:
     name: Test Package
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows, ubuntu, macos]
+    runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --experimental-vm-modules
     steps:


### PR DESCRIPTION
This pull request adjusts the `test-package` job to exclusively run on the latest Ubuntu version, removing Matrix OS support for that job. It resolves #214.