### PR TITLE
Merge Documentation Generation and Deployment Jobs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,10 +4,23 @@ on:
   push:
     branches: [main]
 jobs:
-  generate-docs:
-    name: Generate Documentation
+  deploy-pages:
+    name: Deploy Pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v3.0.6
+
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
@@ -26,28 +39,10 @@ jobs:
       - name: Generate Documentation
         run: yarn doc
 
-      - name: Upload Documentation as Pages
+      - name: Upload Documentation
         uses: actions/upload-pages-artifact@v2.0.0
         with:
           path: docs
-
-  deploy-pages:
-    name: Deploy Pages
-    needs: generate-docs
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    concurrency:
-      group: pages
-      cancel-in-progress: false
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v3.0.6
 
       - name: Deploy Pages
         id: deployment


### PR DESCRIPTION
This pull request merge the `generate-docs` job of the `deploy` workflow to `deploy-pages` job of the same workflow. It closes #216.