### PR TITLE
Re-enable Jest Globals Injection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,12 @@
       }
     },
     {
+      "files": ["**/*.test.*"],
+      "env": {
+        "jest": true
+      }
+    },
+    {
       "files": ["package.json"],
       "plugins": ["json-files"],
       "rules": {

--- a/jest.config.json
+++ b/jest.config.json
@@ -8,7 +8,6 @@
       "statements": 100
     }
   },
-  "injectGlobals": false,
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.mjs$": "<rootDir>/dist/$1.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@jest/globals": "^29.7.0",
     "@types/node": "^20.10.0",
     "@types/yargs": "^17.0.32",
     "@typescript-eslint/eslint-plugin": "^6.13.1",

--- a/src/sequence.test.js
+++ b/src/sequence.test.js
@@ -1,4 +1,3 @@
-import { it, expect } from "@jest/globals";
 import { fibonacciSequence } from "./sequence.mjs";
 
 it("should generate a fibonacci sequence", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,7 +3709,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "my_fibonacci@workspace:."
   dependencies:
-    "@jest/globals": "npm:^29.7.0"
     "@types/node": "npm:^20.10.0"
     "@types/yargs": "npm:^17.0.32"
     "@typescript-eslint/eslint-plugin": "npm:^6.13.1"


### PR DESCRIPTION
This pull request re-enables Jest globals injection, effectively removes [@jest/globals](https://www.npmjs.com/package/@jest/globals) from the dependencies. This pull request also add rules in the ESLint that specify Jest environment on test files. It closes #202.