### PR TITLE
Use Yarn Install Action in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,17 +12,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Create Package
         run: corepack yarn pack
@@ -39,17 +30,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Generate Documentation
         run: corepack yarn doc

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,17 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Generate Documentation
         run: corepack yarn doc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,20 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Enable Yarn
-        run: corepack enable yarn
+      - name: Install Dependencies
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Check Yarn Version
         run: corepack yarn set version stable && git diff --exit-code HEAD
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install Dependencies
-        run: corepack yarn install
 
       - name: Check Format
         run: corepack yarn format && git diff --exit-code HEAD
@@ -45,17 +36,8 @@ jobs:
         with:
           node-version: latest
 
-      - name: Enable Yarn
-        run: corepack enable yarn
-
-      - name: Cache Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: .yarn
-          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Dependencies
-        run: corepack yarn install
+        uses: threeal/yarn-install-action@v1.0.0
 
       - name: Test Package
         run: corepack yarn test


### PR DESCRIPTION
This pull request modifies all workflows in this project to use [Yarn Install Action](https://github.com/threeal/yarn-install-action/) for installing dependencies for this project. It closes #239.