### PR TITLE
Remove Test Match Option in Jest Configuration

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -10,6 +10,5 @@
   },
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.mjs$": "<rootDir>/dist/$1.mjs"
-  },
-  "testMatch": ["**/*.test.js"]
+  }
 }


### PR DESCRIPTION
This pull request removes the `testMatch` option from the Jest configuration file. It closes #242.