### PR TITLE
Use LTS Version of Node.js in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20
+
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 
@@ -29,6 +34,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20
+
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: latest
+          node-version: 20
 
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 20
+
       - name: Install Dependencies
         uses: threeal/yarn-install-action@v1.0.0
 


### PR DESCRIPTION
This pull request adds step for setting up Node.js with version `20` (current LTS) in all workflows that use Node.js. It closes #245.