### PR TITLE
Audit Permission of Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,7 +8,6 @@ jobs:
     name: Deploy Pages
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
This pull request audits the permission of the deployment workflow (`deploy.yaml`) by removing the `contents` permission from the `deploy-pages` job. The `contents` permission is removed because it is no longer required in this workflow.