### PR TITLE
Use Prettier with Cache Enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "doc": "typedoc src/index.mts",
-    "format": "prettier --write .",
+    "format": "prettier --write --cache .",
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
     "test": "tsc && jest"


### PR DESCRIPTION
This pull request resolves #303 by modifying the `format` script to call the `prettier` command with the `--cache` option enabled.