### PR TITLE
Simplify ESLint Configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended"],
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.mts", "**/*.ts"],
+      "files": ["**/*.[cm]ts"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "plugins": ["eslint-plugin-tsdoc"],
       "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,11 +9,7 @@
     {
       "files": ["**/*.mts", "**/*.ts"],
       "extends": ["plugin:@typescript-eslint/recommended"],
-      "parser": "@typescript-eslint/parser",
-      "parserOptions": {
-        "project": ["tsconfig.json"]
-      },
-      "plugins": ["@typescript-eslint", "eslint-plugin-tsdoc"],
+      "plugins": ["eslint-plugin-tsdoc"],
       "rules": {
         "tsdoc/syntax": "error"
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.56.0",
-    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-json-files": "^4.1.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1977,17 +1977,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "eslint-config-prettier@npm:9.1.0"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10c0/6d332694b36bc9ac6fdb18d3ca2f6ac42afa2ad61f0493e89226950a7091e38981b66bac2b47ba39d15b73fff2cd32c78b850a9cf9eed9ca9a96bfb2f3a2f10d
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-json-files@npm:^4.1.0":
   version: 4.1.0
   resolution: "eslint-plugin-json-files@npm:4.1.0"
@@ -3715,7 +3704,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
     "@typescript-eslint/parser": "npm:^6.21.0"
     eslint: "npm:^8.56.0"
-    eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-json-files: "npm:^4.1.0"
     eslint-plugin-tsdoc: "npm:^0.2.17"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #318 by introducing the following changes:
- Simplifies the configuration for TypeScript files by removing the `@typescript-eslint/parser` parser and the `@typescript-eslint` plugins configuration because they are already set when extending from the `plugin:@typescript-eslint/recommended`.
- Removes the `eslint-config-prettier` configuration because it is no longer needed.
- Simplifies the glob pattern for TypeScript files to `**/*.[cm]ts`.