### PR TITLE
Fix Glob Pattern in ESLint Configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
   },
   "overrides": [
     {
-      "files": ["**/*.*([cm])ts"],
+      "files": ["**/*.?([cm])ts"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "plugins": ["eslint-plugin-tsdoc"],
       "rules": {


### PR DESCRIPTION
This pull request resolves #323 by modifying the glob pattern for TypeScript files to be `**/*.?([cm])ts`. This change should be part of #318.