### PR TITLE
Remove Parser Options in ESLint Configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "root": true,
   "extends": ["eslint:recommended"],
-  "parserOptions": {
-    "ecmaVersion": 2022,
-    "sourceType": "module"
-  },
   "overrides": [
     {
       "files": ["**/*.*([cm])ts"],


### PR DESCRIPTION
This pull request resolves #325 by removing the `parserOptions` entry from the `.eslintrc.json` configuration file. This change should be part of #322.