### PR TITLE
Configure Jest to Run Tests Verbosely

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -13,5 +13,6 @@
   },
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
-  }
+  },
+  "verbose": true
 }


### PR DESCRIPTION
This pull request resolves #339 by configuring `verbose` option to `true` in the `jest.config.json` file.