### PR TITLE
Only Lint Source Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "format": "prettier --write --cache .",
-    "lint": "eslint --ignore-path .gitignore .",
+    "lint": "eslint src",
     "prepack": "tsc",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request resolves #356 by modifying the `lint` command to only process source files in the `src` directory.