### PR TITLE
Disable Jest from Writing Report Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 !.eslint*
 !.git*
 
-coverage/
 dist/
 node_modules/
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,5 +1,6 @@
 {
   "collectCoverage": true,
+  "coverageReporters": ["text"],
   "coverageThreshold": {
     "global": {
       "branches": 100,


### PR DESCRIPTION
This pull request resolves #385 by disabling Jest from writing report files in the `coverage` directory, thereby cleaning up the workspace from unused generated files.