### PR TITLE
Fix Unused Ignore in ESLint Configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,6 @@ export default [
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
   {
-    ignores: [".*", "coverage", "dist"],
+    ignores: [".*", "dist"],
   },
 ];


### PR DESCRIPTION
This pull request remove unused value that ignore `coverage` path in the `eslint.config.js` configuration file. This change should be part of #383.