### PR TITLE
Run ESLint with No File Arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "format": "prettier --write --cache .",
-    "lint": "eslint .",
+    "lint": "eslint",
     "prepack": "tsc",
     "test": "jest"
   },


### PR DESCRIPTION
This pull request simply resolves #394 by modifying the `lint` script in the `package.json` file to run the `eslint` command with no file arguments.