### PR TITLE
Set Node Options for Running Tests

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.git*
 
 dist/


### PR DESCRIPTION
This pull request resolves #483 by utilizing the `.env.yarn` file to set the `NODE_OPTIONS` environment variable for running tests.