### PR TITLE
Specify Upload Artifact Options in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,3 +28,5 @@ jobs:
         with:
           name: package
           path: package.tgz
+          if-no-files-found: error
+          overwrite: true


### PR DESCRIPTION
This pull request resolves #547 by specifying the options for the Upload Artifact action used in the `build` workflow. The changes set `if-no-files-found` to `error`, ensuring the workflow checks if the files to be uploaded are missing. Additionally, the `overwrite` option is set to `true`, allowing files to be re-uploaded if the workflow run is restarted.