### PR TITLE
Remove Node Options for Test

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,1 +1,0 @@
-NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .*
-!.env.yarn
 !.git*
 !.nvmrc
 


### PR DESCRIPTION
This pull request resolves #590 by removing the `.env.yarn` file, thereby disabling `--experimental-vm-modules` for running tests.