### PR TITLE
Bump TypeScript Target to ES2024

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "node16",
     "declaration": true,
     "outDir": "dist",
-    "target": "es2022",
+    "target": "es2024",
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
This pull request updates the TypeScript target to [ES2024](https://tc39.es/ecma262/2024/) by configuring the `target` option in the `tsconfig.json` file.