### PR TITLE
Fix Warning During Test

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "node16",
     "declaration": true,
     "outDir": "dist",
-    "target": "es2024",
+    "target": "es2023",
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
This pull request resolves #651 by downgrading TypeScript to target ES2023 to fix warnings with Vitest.