### PR TITLE
Remove Upload Package Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,4 @@ jobs:
         run: pnpm test
 
       - name: Package Library
-        run: pnpm pack --out package.tgz
+        run: pnpm pack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,10 +31,3 @@ jobs:
 
       - name: Package Library
         run: pnpm pack --out package.tgz
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.1
-        with:
-          path: package.tgz
-          if-no-files-found: error
-          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 dist/
 node_modules/
 
-package.tgz
+*.tgz

--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ When the project is complete, package the library by running:
 pnpm pack
 ```
 
-This will create a `package.tgz` file, which can be included in the release. Ensure the project is at the correct version and has been pushed to the upstream repository. For more information on releasing a project, refer to [this documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+This will create a tarball file, which can be included in the release. Ensure the project is at the correct version and has been pushed to the upstream repository. For more information on releasing a project, refer to [this documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).


### PR DESCRIPTION
This pull request resolves #726 by removing the "Upload Package" step from the `build.yaml` workflow. Additionally, this change updates the template to use the default output name for packaging the library.