### PR TITLE
Remove Unnecessary Configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,5 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
-  {
-    ignores: [".*", "dist"],
-  },
+  { ignores: ["dist"] },
 ];

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "prepack": "tsc",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "yargs": "^17.7.2"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    watch: false,
     coverage: {
       all: false,
       enabled: true,


### PR DESCRIPTION
This pull request resolves #728 by removing the following configurations:  
- Removing `.*` files from being ignored in `eslint.config.js`.  
- Removing the `watch` option set to `false` in `vitest.config.ts`.