### PR TITLE
Include `.npmrc` When Checking Types in Lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,8 +11,9 @@ pre-commit:
       run: pnpm tsc --noEmit
       glob:
         - src/*.ts
-        - tsconfig.json
+        - .npmrc
         - pnpm-lock.yaml
+        - tsconfig.json
       exclude:
         - src/*.test.ts
 


### PR DESCRIPTION
This pull request resolves #730 by including the `.npmrc` file to the glob list of the `check types` job in the Lefthook configuration. This change also sort the glob list accordingly.