### PR TITLE
Bump Node to Version 24.0.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=24.0.1
+use-node-version=24.0.2


### PR DESCRIPTION
This pull request bumps the Node version specified in the `.npmrc` file to version [24.0.2](https://github.com/nodejs/node/releases/tag/v24.0.2).