### PR TITLE
Move Built Dependencies Config to `pnpm-workspace.yaml`

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,7 @@ pre-commit:
       glob:
         - package.json
         - pnpm-lock.yaml
+        - pnpm-workspace.yaml
 
     - name: fix formatting
       run: pnpm prettier --write --ignore-unknown {staged_files}

--- a/package.json
+++ b/package.json
@@ -41,11 +41,5 @@
     "typescript-eslint": "^8.32.1",
     "vite-node": "^3.1.4",
     "vitest": "^3.0.5"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - esbuild
+  - lefthook


### PR DESCRIPTION
This pull request resolves #800 by moving the `onlyBuiltDependencies` config from the `package.json` file to the `pnpm-workspace.yaml` file.