### PR TITLE
Test All Files

### DIFF
--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -1,0 +1,10 @@
+import { expect, it, vi } from "vitest";
+
+it("should print a fibonacci sequence", async () => {
+  const spy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+  process.argv = ["node", "bin.js", "5"];
+  await import("./bin.js");
+
+  expect(spy).toHaveBeenCalledExactlyOnceWith("1 1 2 3 5\n");
+});

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from "vitest";
+import { expect, it } from "vitest";
 import { fibonacciSequence } from "./lib.js";
 
 it("should generate a fibonacci sequence", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      all: false,
       enabled: true,
       reporter: ["text"],
       thresholds: { 100: true },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     coverage: {
       enabled: true,
-      reporter: ["text"],
+      reporter: "text",
       thresholds: { 100: true },
     },
   },


### PR DESCRIPTION
This pull request resolves #820 mainly by removing the `test.coverage.all` configuration in `vitest.config.ts`, which by default makes Vitest check test coverage on all files. To satisfy the coverage requirements, this change also adds a test for the `src/bin.ts` file.

Additionally, this pull request modifies other parts of the codebase, with details available in the individual commits.