### PR TITLE
Fix Prettier Plugin Organize Imports Not Configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 dist/
 node_modules/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}


### PR DESCRIPTION
This pull request resolves #882 by adding the `.prettierrc.json` file, which should have been included in #879.