### PR TITLE
Update CI to validate pre-commit hooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,25 +12,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Install Lefthook
+        run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/evilmartians/lefthook/setup.deb.sh' | sudo -E bash
+          sudo apt install lefthook
+
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
         with:
           version: 10.33.4
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Check types
-        run: pnpm tsc
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files
 
       - name: Test
         run: pnpm test
-
-      - name: Check formatting
-        run: pnpm prettier --check .
-
-      - name: Check lint
-        run: pnpm eslint
 
       - name: Package
         run: pnpm pack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,5 +46,5 @@ The development workflow uses **jiti** to run `src/bin.ts` directly without a co
 
 - **ESLint** uses flat config (`eslint.config.ts`) with `typescript-eslint` strict + stylistic type-checked rules.
 - **Prettier** uses `prettier-plugin-organize-imports` — import order is auto-managed.
-- **Lefthook** is an external tool (not a dev dependency) that manages Git hooks. It must be installed independently and set up with `lefthook install`. Pre-commit hooks run type-check → format → lint with `fail_on_changes: always`, so hooks can auto-fix files but will abort the commit if any file changed, requiring a re-stage.
+- **Lefthook** is an external tool (not a dev dependency) that manages Git hooks. It must be installed independently and set up with `lefthook install`. Pre-commit hooks run type-check → format → lint with `fail_on_changes: always`, so hooks can auto-fix files but will abort the commit if any file changed, requiring a re-stage. The CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
 - **Vitest** requires 100% code coverage (lines, functions, branches, statements) enforced via the `coverage` threshold in `vitest.config.ts`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This template provides a basic Node.js project containing a sample library writt
 - Uses [pnpm](https://pnpm.io/) as the package manager.
 - Supports formatting with [Prettier](https://prettier.io/), linting with [ESLint](https://eslint.org/), and testing with [Vitest](https://vitest.dev/).
 - Fixes formatting and linting during pre-commit hooks using [Lefthook](https://lefthook.dev/).
-- Preconfigured workflows for [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions).
+- Preconfigured [Dependabot](https://docs.github.com/en/code-security/dependabot) and [GitHub Actions](https://github.com/features/actions) workflows that validate the pre-commit hook.
 
 ## Usage
 


### PR DESCRIPTION
Resolves #1082.

## Summary

- Replaces individual CI check steps (install deps, type-check, format, lint) with Lefthook installation + `lefthook run pre-commit --all-files`
- Updates `README.md` and `CLAUDE.md` to reflect that CI now validates the pre-commit hook

## Test plan

- [ ] CI passes on this PR
- [ ] `lefthook run pre-commit --all-files` step covers type-check, formatting, and lint
- [ ] `Test` and `Package` steps still run independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)