### PR TITLE
Replace Commander.js with CAC in CLI code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ pnpm start             # Run CLI directly via jiti (no compile step needed)
 This is a minimal Node.js library + CLI starter template written in TypeScript targeting Node 24 (ESM).
 
 - **`src/lib.ts`** — The library's public API (currently a Fibonacci sequence generator as a placeholder example).
-- **`src/bin.ts`** — CLI entry point built with Commander.js that wraps the library.
+- **`src/bin.ts`** — CLI entry point built with CAC that wraps the library.
 - **`src/*.test.ts`** — Vitest test files co-located with source.
 
 ### Build outputs

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A minimal [Node.js](https://nodejs.org/en) project template written in [TypeScri
 
 ## What's Included
 
-- **TypeScript** library with [ESM](https://nodejs.org/api/esm.html) support and a CLI entry point using [Commander.js](https://github.com/tj/commander.js)
+- **TypeScript** library with [ESM](https://nodejs.org/api/esm.html) support and a CLI entry point using [CAC](https://github.com/cacjs/cac)
 - **[pnpm](https://pnpm.io/)** as the package manager
 - **Formatting** with [Prettier](https://prettier.io/) and **linting** with [ESLint](https://eslint.org/)
 - **Testing** with [Vitest](https://vitest.dev/) — 100% code coverage required

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "commander": "^14.0.3"
+    "cac": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      commander:
-        specifier: ^14.0.3
-        version: 14.0.3
+      cac:
+        specifier: ^7.0.0
+        version: 7.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -574,13 +574,13 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
+
   chai@6.2.1:
     resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
-
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1465,9 +1465,9 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  chai@6.2.1: {}
+  cac@7.0.0: {}
 
-  commander@14.0.3: {}
+  chai@6.2.1: {}
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,15 +1,20 @@
 #!/usr/bin/env node
 
-import { program } from "commander";
+import cac from "cac";
 import { fibonacciSequence } from "./lib.js";
 
-program
-  .name("my_fibonacci")
-  .version("0.0.0")
-  .description("Generate a Fibonacci sequence up to the given number of terms.")
-  .argument("<n>", "The number of terms", parseInt)
-  .action((n: number) => {
-    const sequence = fibonacciSequence(n);
+const cli = cac("my_fibonacci");
+
+cli
+  .command(
+    "<n>",
+    "Generate a Fibonacci sequence up to the given number of terms.",
+  )
+  .action((n: string) => {
+    const sequence = fibonacciSequence(parseInt(n));
     process.stdout.write(`${sequence.join(" ")}\n`);
-  })
-  .parse();
+  });
+
+cli.version("0.0.0");
+cli.help();
+cli.parse();


### PR DESCRIPTION
## Summary

- Replace `commander` dependency with `cac` for a more actively maintained library with better TypeScript support
- Update `src/bin.ts` to use the CAC API
- Update references in `README.md` and `CLAUDE.md`

Resolves #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)