### PR TITLE
Replace it/should with test in test files

### DIFF
--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -1,6 +1,6 @@
-import { expect, it, vi } from "vitest";
+import { expect, test, vi } from "vitest";
 
-it("should print a fibonacci sequence", async () => {
+test("prints the fibonacci sequence to stdout", async () => {
   const spy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
   process.argv = ["node", "bin.js", "5"];

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,7 +1,7 @@
-import { expect, it } from "vitest";
+import { expect, test } from "vitest";
 import { fibonacciSequence } from "./lib.js";
 
-it("should generate a fibonacci sequence", () => {
+test("returns a fibonacci sequence of the given length", () => {
   expect(fibonacciSequence(1)).toStrictEqual([1]);
   expect(fibonacciSequence(2)).toStrictEqual([1, 1]);
   expect(fibonacciSequence(5)).toStrictEqual([1, 1, 2, 3, 5]);


### PR DESCRIPTION
Resolves #1099.

## Summary

- Replaced `it('should ...')` with `test(...)` in all test files
- Updated test descriptions to drop the `should` prefix and use more precise language

## Test plan

- [x] `pnpm test` passes with 100% coverage