### PR TITLE
Remove pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,0 @@
-packages: [.]
-onlyBuiltDependencies:
-  - esbuild
-  - lefthook


### PR DESCRIPTION
Closes #1106.

`pnpm-workspace.yaml` contained only an `onlyBuiltDependencies` list (`esbuild`, `lefthook`) and a `packages: [.]` workaround entry. Since neither `esbuild` nor `lefthook` are pnpm dependencies anymore (Lefthook was removed in #1083), the `onlyBuiltDependencies` section serves no purpose.

The `packages: [.]` line was added in #849 solely to work around a Dependabot bug (#848) where Dependabot fails when `pnpm-workspace.yaml` exists without a `packages` field. With no other meaningful content in the file, removing it entirely is the right move.