### PR TITLE
Add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "vite": "^8.0.13",
     "vitest": "^4.1.6"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "packageManager": "pnpm@10.33.4"
 }


### PR DESCRIPTION
Closes #1108

Adds `"engines": { "node": ">=24" }` to `package.json` to complement the existing `use-node-version` in `.npmrc` with a standard, tool-agnostic minimum version declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)