### PR TITLE
Remove redundant `start` and `test` scripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         run: lefthook run pre-commit --all-files
 
       - name: Test
-        run: pnpm test
+        run: pnpm vitest run
 
       - name: Package
         run: pnpm pack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,18 +11,16 @@ This is a minimal Node.js library and CLI starter template. The Fibonacci sequen
 ## Commands
 
 ```sh
-pnpm test              # Run all tests
-pnpm vitest run <file> # Run a single test file (e.g. src/lib.test.ts)
-pnpm vitest            # Run tests in watch mode
+vitest run             # Run all tests
+vitest run <file>      # Run a single test file (e.g. src/lib.test.ts)
 
 pnpm tsc               # Type-check without emitting
-pnpm eslint            # Lint
-pnpm eslint --fix      # Lint and auto-fix
-pnpm prettier --check . # Check formatting
-pnpm prettier --write . # Fix formatting
+eslint                 # Lint
+eslint --fix           # Lint and auto-fix
+prettier --check .     # Check formatting
+prettier --write .     # Fix formatting
 
 pnpm prepack           # Compile TypeScript to dist/ (tsc -p tsconfig.build.json)
-pnpm start             # Run CLI directly via jiti (no compile step needed)
 ```
 
 ## Architecture
@@ -40,7 +38,7 @@ TypeScript compiles via `tsconfig.build.json` into `dist/`:
 - `dist/lib.js` + `dist/lib.d.ts` — library entry (exported as `"."`)
 - `dist/bin.js` — CLI binary (exported as `"./bin"` and registered as the `nodejs-starter` bin)
 
-The development workflow uses **jiti** to run `src/bin.ts` directly without a compile step (`pnpm start`).
+The development workflow uses **jiti** to run TypeScript source files directly without a compile step.
 
 ### Tooling details
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc -p tsconfig.build.json",
-    "start": "jiti src/bin.ts",
-    "test": "vitest run"
+    "prepack": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "commander": "^15.0.0"


### PR DESCRIPTION
Closes #1110.

The `start` and `test` scripts are just aliases for `jiti src/bin.ts` and `vitest run` — commands clear enough to call directly. The project already avoids adding scripts for `format`, `lint`, etc. for this same reason, so this brings `start` and `test` in line with that convention.

`prepack` is kept since it's a lifecycle hook that runs automatically and uses a non-default flag (`-p tsconfig.build.json`).