### PR TITLE
Fix outdated conventions in ESLint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,17 +1,16 @@
-import eslint from "@eslint/js";
+import js from "@eslint/js";
 import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig(
   globalIgnores(["dist"]),
-  eslint.configs.recommended,
+  js.configs.recommended,
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {
     languageOptions: {
       parserOptions: {
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
       },
     },
   },


### PR DESCRIPTION
Closes #1112

## Changes

- Rename the `@eslint/js` import alias from `eslint` to `js`, matching the convention shown in the current [ESLint getting started docs](https://eslint.org/docs/latest/use/getting-started).
- Remove the redundant `tsconfigRootDir` option from `parserOptions`. As noted in the [typescript-eslint typed linting docs](https://typescript-eslint.io/getting-started/typed-linting/), `projectService` already defaults to the directory of `eslint.config.ts`, making this option unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)