### PR TITLE
Improve package metadata and sample conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ This is a minimal Node.js library + CLI starter template written in TypeScript t
 TypeScript compiles via `tsconfig.build.json` into `dist/`:
 
 - `dist/lib.js` + `dist/lib.d.ts` — library entry (exported as `"."`)
-- `dist/bin.js` — CLI binary (exported as `"./bin"` and registered as the `nodejs-starter` bin)
+- `dist/bin.js` — CLI binary (exported as `"./bin"` and registered as the `fibonacci-sample` bin)
 
 The development workflow uses **jiti** to run TypeScript source files directly without a compile step.
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "my_fibonacci",
-  "version": "0.0.0",
-  "description": "A sample Node.js project",
+  "name": "fibonacci-sample",
+  "version": "0.1.0",
+  "description": "Sample library and CLI for generating Fibonacci sequences",
   "keywords": [
-    "sample",
-    "fibonacci"
+    "fibonacci",
+    "math"
   ],
   "homepage": "https://github.com/threeal/nodejs-starter#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- Renames the sample package from `my_fibonacci` (poor naming) to `fibonacci-sample` (kebab-case, descriptive)
- Bumps version from `0.0.0` to `0.1.0` to follow conventional initial-release versioning
- Rewrites description from the generic `"A sample Node.js project"` to `"Sample library and CLI for generating Fibonacci sequences"`, following the npm convention of leading with the subject rather than an article
- Trims keywords from `["sample", "fibonacci"]` to `["fibonacci", "math"]` — removes `sample` (not a real search term) and adds `math` for domain discoverability
- Fixes `CLAUDE.md` build output docs to reference `fibonacci-sample` as the registered bin name instead of the stale `nodejs-starter`