### PR TITLE
Rewrite CLAUDE.md with improved structure and detail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,48 +2,77 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-> **Template notice:** This file describes the template repository itself. If you've created a project from this template, replace this content with guidance specific to your project.
+> **Template notice:** This file describes the template repository itself. If working in a project derived from this template, inform the user that this CLAUDE.md still contains template guidance and should be updated with project-specific content.
 
 ## About This Repository
 
-This is a minimal Node.js library and CLI starter template. The Fibonacci sequence code in `src/` is a placeholder — replace it with your actual library and CLI logic when starting a new project.
-
-## Commands
-
-```sh
-vitest run             # Run all tests
-vitest run <file>      # Run a single test file (e.g. src/lib.test.ts)
-
-pnpm tsc               # Type-check without emitting
-eslint                 # Lint
-eslint --fix           # Lint and auto-fix
-prettier --check .     # Check formatting
-prettier --write .     # Fix formatting
-
-pnpm prepack           # Compile TypeScript to dist/ (tsc -p tsconfig.build.json)
-```
+This is a minimal Node.js library and CLI starter template written in TypeScript targeting Node 24 (ESM). The Fibonacci sequence code in `src/` is a placeholder — replace it with your actual library and CLI logic when starting a new project.
 
 ## Architecture
 
-This is a minimal Node.js library + CLI starter template written in TypeScript targeting Node 24 (ESM).
+### Source Files
 
 - **`src/fibonacci.ts`** — The library implementation (currently a Fibonacci sequence generator as a placeholder example).
 - **`src/index.ts`** — The library's public API (re-exports from implementation modules).
 - **`src/cli.ts`** — CLI entry point built with Commander.js that wraps the library.
 - **`src/*.test.ts`** — Vitest test files co-located with source.
 
-### Build outputs
+### TypeScript Configuration
 
-TypeScript compiles via `tsconfig.build.json` into `dist/`:
+Both configs extend `@tsconfig/node24`, which sets `module: nodenext` and `moduleResolution: node16`. This requires import paths to use `.js` extensions even when importing `.ts` source files.
 
-- `dist/index.js` + `dist/index.d.ts` — library entry (exported as `"."`)
-- `dist/cli.js` — CLI binary (registered as the `fibonacci-sample` bin)
+- **`tsconfig.json`** — Type-check config with `noEmit: true`; used by `pnpm tsc`.
+- **`tsconfig.build.json`** — Build config; includes `src/`, excludes test files; sets `rootDir: "src"` so output maps directly to `dist/` (not `dist/src/`); includes `types: ["node"]`; emits declaration and JS files.
 
-The development workflow uses **jiti** to run TypeScript source files directly without a compile step.
+### Build Outputs
 
-### Tooling details
+- `dist/index.js` + `dist/index.d.ts` — library entry (exported as `"."`).
+- `dist/cli.js` — CLI binary (registered as the `fibonacci-sample` bin via shorthand `"bin": "dist/cli.js"` in `package.json`, which derives the name from the package name).
 
-- **ESLint** uses flat config (`eslint.config.ts`) with `typescript-eslint` strict + stylistic type-checked rules.
+## Tooling
+
+- **pnpm** is the package manager. It uses `use-node-version` in `.npmrc` to select the Node.js version; `packageManager` in `package.json` pins the pnpm version; `engines.node` asserts Node >=24.
+- **ESLint** uses flat config (`eslint.config.ts`) with `@eslint/js` recommended rules and `typescript-eslint` strict + stylistic type-checked rules.
 - **Prettier** uses `prettier-plugin-organize-imports` — import order is auto-managed.
-- **Lefthook** is an external tool (not a dev dependency) that manages Git hooks. It must be installed independently and set up with `lefthook install`. Pre-commit hooks run type-check → format → lint with `fail_on_changes: always`, so hooks can auto-fix files but will abort the commit if any file changed, requiring a re-stage. The CI also validates the pre-commit hook by running `lefthook run pre-commit --all-files`.
-- **Vitest** requires 100% code coverage (lines, functions, branches, statements) enforced via the `coverage` threshold in `vitest.config.ts`.
+- **Lefthook** manages Git hooks via `lefthook.yaml`. It is a standalone binary, not a pnpm package.
+- **jiti** runs TypeScript files directly without compiling.
+- **Vitest** uses `vitest.config.ts` with `coverage.enabled: true`, `reporter: "text"`, and `thresholds: { 100: true }`, requiring 100% coverage across all metrics on every test run.
+- **Dependabot** keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
+
+## Running TypeScript
+
+Use `pnpm jiti` to execute any TypeScript file directly without compiling:
+
+```sh
+pnpm jiti <file> [args]
+```
+
+## Testing
+
+```sh
+pnpm vitest run             # Run all tests
+pnpm vitest run <file>      # Run a single test file
+```
+
+Coverage is always enabled and computed for all files imported during the test run. Running a single test file may fail the 100% threshold if it imports a source file that another test is responsible for fully covering — use the full suite for accurate results.
+
+## Checking and Fixing
+
+Use Lefthook to run the same steps as the pre-commit hook:
+
+```sh
+lefthook run pre-commit              # staged files only (default)
+lefthook run pre-commit --all-files  # all files — matches what CI runs
+```
+
+This installs dependencies, type-checks, fixes formatting, and fixes lint — in that order, stopping on the first failure. If any file changes during the run, it also fails and shows a diff of what changed — re-stage the changed files and retry.
+
+Individual commands (manual fallback if needed): `pnpm tsc`, `pnpm prettier --write .`, `pnpm eslint --fix`.
+
+## Building and Packaging
+
+Use `pnpm pack` to build and package the library into a tarball (e.g. for publishing to npm). The `prepack` script runs `tsc -p tsconfig.build.json` automatically before packing.
+
+## CI
+
+CI runs on push to `main`, pull requests, and manual dispatch. It runs the pre-commit hook on all files, then the full test suite, then `pnpm pack`. See `.github/workflows/ci.yaml` for full details.


### PR DESCRIPTION
## Summary

- Replaces the flat `## Commands` dump with dedicated sections per workflow: **Running TypeScript**, **Testing**, **Checking and Fixing**, **Building and Packaging**, and **CI** — each with the relevant commands and surrounding context
- Splits `## Architecture` into subsections: **Source Files**, **TypeScript Configuration**, and **Build Outputs** — and adds full detail on both tsconfig files, the `.js` extension requirement, and the `bin` shorthand in `package.json`
- Expands `## Tooling` to cover pnpm, Dependabot, and jiti (previously missing), and trims the Lefthook entry to its essential facts
- Moves the "TypeScript targeting Node 24 (ESM)" description from Architecture into the About section where it belongs; removes the duplicate line in Architecture
- Updates the template notice to address Claude Code directly rather than a generic end-user
- Fixes the `bin` entry to note it uses shorthand notation (name derived from package name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)