### PR TITLE
Bump pnpm to version 10.34.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
         with:
-          version: 10.33.4
+          version: 10.34.1
 
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files

--- a/package.json
+++ b/package.json
@@ -49,5 +49,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@10.34.1"
 }


### PR DESCRIPTION
This pull request bumps pnpm to version [10.34.1](https://github.com/pnpm/pnpm/releases/tag/v10.34.1).