### PR TITLE
Update CLAUDE.md and README.md to follow project-starter conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,41 +12,65 @@ This is a minimal Node.js library and CLI starter template written in TypeScript
 
 ### Source Files
 
+- **`src/cli/commands/`** — Individual yargs command modules; each exports a `createXxxCommand()` factory that accepts injected streams/deps for testability.
+- **`src/cli/index.ts`** — CLI entry point built with yargs that wires commands and parses `process.argv`.
 - **`src/fibonacci.ts`** — The library implementation (currently a Fibonacci sequence generator as a placeholder example).
 - **`src/index.ts`** — The library's public API (re-exports from implementation modules).
-- **`src/cli/index.ts`** — CLI entry point built with yargs that wires commands and parses `process.argv`.
-- **`src/cli/commands/`** — Individual yargs command modules; each exports a `createXxxCommand()` factory that accepts injected streams/deps for testability.
 - **`src/*.test.ts`** — Vitest test files co-located with source.
-
-### TypeScript Configuration
-
-Both configs extend `@tsconfig/node24`, which sets `module: nodenext` and `moduleResolution: node16`. This requires import paths to use `.js` extensions even when importing `.ts` source files.
-
-- **`tsconfig.json`** — Type-check config with `noEmit: true`; used by `pnpm tsc`.
-- **`tsconfig.build.json`** — Build config; includes `src/`, excludes test files; sets `rootDir: "src"` so output maps directly to `dist/` (not `dist/src/`); includes `types: ["node"]`; emits declaration and JS files.
 
 ### Build Outputs
 
-- `dist/index.js` + `dist/index.d.ts` — library entry (exported as `"."`).
-- `dist/cli/index.js` — CLI binary (registered as the `fibonacci-sample` bin via shorthand `"bin": "dist/cli/index.js"` in `package.json`, which derives the name from the package name).
+- **`dist/cli/index.js`** — CLI binary.
+- **`dist/index.js`** + **`dist/index.d.ts`** — Library entry (exported as `"."`).
 
 ## Tooling
 
-- **pnpm** is the package manager. `devEngines.runtime` in `package.json` specifies the Node.js version (`onFail: "download"` triggers automatic download if needed); `packageManager` pins the pnpm version; `engines.node` asserts Node >=24.
-- **ESLint** uses flat config (`eslint.config.ts`) with `@eslint/js` recommended rules and `typescript-eslint` strict + stylistic type-checked rules.
-- **Prettier** uses `prettier-plugin-organize-imports` — import order is auto-managed.
-- **Lefthook** manages Git hooks via `lefthook.yaml`. It is a standalone binary, not a pnpm package.
-- **jiti** runs TypeScript files directly without compiling.
-- **Vitest** uses `vitest.config.ts` with `coverage.enabled: true`, `reporter: "text"`, and `thresholds: { 100: true }`, requiring 100% coverage across all metrics on every test run.
-- **Dependabot** keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
+### Dependabot
 
-## Running TypeScript
+Keeps GitHub Actions and npm dependencies up to date automatically via `.github/dependabot.yaml`.
 
-Use `pnpm jiti` to execute any TypeScript file directly without compiling:
+### ESLint
+
+Linter configured in `eslint.config.ts`.
+
+### GitHub Actions
+
+Automates CI. Workflow files:
+
+- **`.github/workflows/ci.yaml`** — Triggers on push to `main`, pull requests, and manual dispatch.
+
+### Lefthook
+
+Git hook manager configured in `lefthook.yaml`.
+
+### pnpm
+
+Package manager. Also manages the Node.js runtime — versions for Node.js and pnpm are pinned in `package.json`.
+
+### Prettier
+
+Formatter configured in `.prettierrc.json` using `prettier-plugin-organize-imports` — import order is auto-managed.
+
+### TypeScript
+
+Type checker and compiler. `tsconfig.json` is used for type checking via `pnpm tsc`; `tsconfig.build.json` is used for compilation via `pnpm pack`.
+
+Both configs set `moduleResolution: node16`, which requires all import paths to use `.js` extensions — even when importing `.ts` source files.
+
+### Vitest
+
+Test runner configured in `vitest.config.ts` with 100% coverage threshold required on every test run.
+
+## Checking and Fixing
+
+Run the pre-commit hook:
 
 ```sh
-pnpm jiti <file> [args]
+lefthook run pre-commit              # staged files only (default)
+lefthook run pre-commit --all-files  # all files — matches what CI runs
 ```
+
+If any file changes during the run, re-stage the changed files and retry.
 
 ## Testing
 
@@ -57,23 +81,6 @@ pnpm vitest run <file>      # Run a single test file
 
 Coverage is always enabled and computed for all files imported during the test run. Running a single test file may fail the 100% threshold if it imports a source file that another test is responsible for fully covering — use the full suite for accurate results.
 
-## Checking and Fixing
-
-Use Lefthook to run the same steps as the pre-commit hook:
-
-```sh
-lefthook run pre-commit              # staged files only (default)
-lefthook run pre-commit --all-files  # all files — matches what CI runs
-```
-
-This installs dependencies, type-checks, fixes formatting, and fixes lint — in that order, stopping on the first failure. If any file changes during the run, it also fails and shows a diff of what changed — re-stage the changed files and retry.
-
-Individual commands (manual fallback if needed): `pnpm tsc`, `pnpm prettier --write .`, `pnpm eslint --fix`.
-
 ## Building and Packaging
 
 Use `pnpm pack` to build and package the library into a tarball (e.g. for publishing to npm). The `prepack` script runs `tsc -p tsconfig.build.json` automatically before packing.
-
-## CI
-
-CI runs on push to `main`, pull requests, and manual dispatch. It runs the pre-commit hook on all files, then the full test suite, then `pnpm pack`. See `.github/workflows/ci.yaml` for full details.

--- a/README.md
+++ b/README.md
@@ -22,33 +22,19 @@ lefthook install
 
 ## Customizing
 
-Replace the placeholder content in `src/` with your actual library implementation.
+Replace or extend the template files to fit your project:
 
-**`src/fibonacci.ts`** — Replace with your own library logic.
-
-**`src/index.ts`** — Update the public API exports to match your library.
-
-**`src/cli/`** — Replace or remove the placeholder CLI commands. Remove this folder and the `bin` entry in `package.json` if your project doesn't need a CLI.
-
-**`package.json`** — Update the project name, description, version, and other metadata.
-
-**`README.md`** and **`CLAUDE.md`** — Replace with documentation suited to your project.
-
-**`LICENSE`** — Replace with your preferred license, or keep it as-is (the template uses the [Unlicense](https://unlicense.org/) — public domain).
+- **`src/cli/`** — Replace or remove the placeholder CLI commands. Remove this folder and the `bin` entry in `package.json` if your project doesn't need a CLI.
+- **`src/fibonacci.ts`** — Replace with your own library logic.
+- **`src/index.ts`** — Update the public API exports to match your library.
+- **`CLAUDE.md`** — Replace with guidance specific to your project.
+- **`LICENSE`** — Replace with your preferred license, or keep the [Unlicense](https://unlicense.org/).
+- **`package.json`** — Update the project name, description, version, and other metadata.
+- **`README.md`** — Replace with a description of your project.
 
 ## Development
 
-Write code in `src/`. Test files live alongside source as `*.test.ts`. Before committing, run the pre-commit hook to install dependencies, type-check, and fix formatting and lint:
-
-```sh
-lefthook run pre-commit
-```
-
-If any files change during the run, re-stage them and retry. The hook also runs automatically on each `git commit` — if it fails, fix the reported issues, re-stage, and commit again.
-
-## Testing
-
-Run the full test suite with:
+Write code in `src/`. Test files live alongside source as `*.test.ts`. Run the test suite with:
 
 ```sh
 pnpm vitest run
@@ -56,9 +42,15 @@ pnpm vitest run
 
 The project enforces 100% code coverage on every run.
 
-## CI
+Before committing, run the pre-commit hook to install dependencies, type-check, and fix formatting and lint:
 
-`.github/workflows/ci.yaml` runs the pre-commit hook, the full test suite, and `pnpm pack` on every push and pull request.
+```sh
+lefthook run pre-commit
+```
+
+If any file changes during the run, re-stage the changed files and retry. The hook also runs automatically on each `git commit` — if it fails, fix the reported issues, re-stage, and commit again.
+
+After committing, push to `main` or open a pull request from another branch — CI will run the pre-commit hook across all files, the full test suite, and `pnpm pack`.
 
 ## Releasing
 
@@ -72,5 +64,5 @@ pnpm publish
 
 For a more opinionated starting point in a specific framework:
 
-- [Action Starter](https://github.com/threeal/action-starter) — JavaScript GitHub Actions
-- [Discord Bot Starter](https://github.com/threeal/discord-bot-starter) — Discord bots with the Sapphire framework
+- **[Action Starter](https://github.com/threeal/action-starter)** — JavaScript GitHub Action projects.
+- **[Discord Bot Starter](https://github.com/threeal/discord-bot-starter)** — Discord bot projects.


### PR DESCRIPTION
## Summary

- Restructured `CLAUDE.md` to follow project-starter conventions: tooling split into named alphabetical subsections, each pointing to its config file; architecture source files sorted with directories first; build outputs updated to use bold formatting; TypeScript section added with a note on the `.js` extension requirement; removed sections whose content is already in config files (CI section, verbose pre-commit job list, ESLint rule names).
- Restructured `README.md` to follow project-starter conventions: customizing section converted to a bullet list sorted alphabetically with `src/` entries first; development section merged with testing content and extended with a post-commit push/CI paragraph; separate Testing and CI sections removed; framework-specific template descriptions aligned with project-starter wording.