### PR TITLE
Use cooldown configuration in Dependabot for npm packages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,4 +9,6 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 1
     versioning-strategy: increase


### PR DESCRIPTION
Resolves #1140

## Summary

- Adds a 1-day cooldown period to the Dependabot npm configuration so PRs are only created for package versions published at least 24 hours ago.

## Test plan

- [x] Verify `.github/dependabot.yaml` is valid and Dependabot picks up the new cooldown setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)